### PR TITLE
Read .cppx files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,13 @@ set(Boost_USE_STATIC_LIBS     ON)
 set(Boost_USE_MULTITHREADED   ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
-find_package(Boost 1.63.0 REQUIRED filesystem)
+find_package(Boost 1.58.0 REQUIRED filesystem)
 
 if (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
     link_directories(${Boost_LIBRARY_DIRS})   
 else()
-    message(FATAL_ERROR "Could not find Boost 1.63.0 or greater (http://www.boost.org/).")
+    message(FATAL_ERROR "Could not find Boost 1.58.0 or greater (http://www.boost.org/).")
 endif()
 #-------------------------------------------------
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -1,7 +1,7 @@
 /*
 	Noel Lopes is a Professor at the Polytechnic of Guarda, Portugal
 	and a Researcher at the CISUC - University of Coimbra, Portugal
-	Copyright (C) 2017 Noel de Jesus Mendonça Lopes
+	Copyright (C) 2017 Noel de Jesus MendonÃ§a Lopes
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/src/console.h
+++ b/src/console.h
@@ -1,7 +1,7 @@
 /*
 	Noel Lopes is a Professor at the Polytechnic of Guarda, Portugal
 	and a Researcher at the CISUC - University of Coimbra, Portugal
-	Copyright (C) 2017 Noel de Jesus Mendonça Lopes
+	Copyright (C) 2017 Noel de Jesus MendonÃ§a Lopes
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@
 #include <iostream>
 
 namespace cppx {
-	
+
 	/// Console class that provides three output streams 
 	/// ([default] Output, Warning and Error), using appropriate 
 	/// terminal colors for each one.
 	/// Uses the rang c++ library for colors in the terminal 
-    /// (https://github.com/agauniyal/rang)
+	/// (https://github.com/agauniyal/rang)
 	class Console {
 
 	private:


### PR DESCRIPTION
- Set the minimum required version of boost to 1.58.0 (instead of 1.63)
- Read the contents of .cppx files to memory